### PR TITLE
Adding more tests for cases in EVM

### DIFF
--- a/test/EventManagerTest.php
+++ b/test/EventManagerTest.php
@@ -187,4 +187,27 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
         $eventManager->trigger('MyEvent2', new Event());
         $this->assertSame(2, $triggerCount);
     }
+
+    public function testWildcardListenerPriorityAgainstNonWildcardListener()
+    {
+        $eventManager = new EventManager();
+
+        $listenersTriggered = [];
+
+        $eventManager->attach('*', function (Event $event) use (&$listenersTriggered) {
+            $listenersTriggered[] = '*';
+        }, 1);
+
+        $eventManager->attach('SpecificListener', function (Event $event) use (&$listenersTriggered) {
+            $listenersTriggered[] = 'SpecificListener';
+        }, 1);
+
+        $eventManager->trigger('SpecificListener', new Event());
+
+        // The order is important - a named listener must be executed before wildcard listener
+        $this->assertSame([
+            'SpecificListener',
+            '*',
+        ], $listenersTriggered);
+    }
 }

--- a/test/EventManagerTest.php
+++ b/test/EventManagerTest.php
@@ -168,4 +168,23 @@ class EventManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(2, $responseCollection->count());
     }
+
+    public function testWildcardListener()
+    {
+        $eventManager = new EventManager();
+
+        $triggerCount = 0;
+
+        $eventManager->attach('*', function (Event $event) use (&$triggerCount) {
+            $triggerCount++;
+        }, 1);
+
+        $this->assertSame(0, $triggerCount);
+
+        $eventManager->trigger('MyEvent1', new Event());
+        $this->assertSame(1, $triggerCount);
+
+        $eventManager->trigger('MyEvent2', new Event());
+        $this->assertSame(2, $triggerCount);
+    }
 }


### PR DESCRIPTION
As requested: https://github.com/bakura10/zend-eventmanager/pull/1#issuecomment-103821212

> - Test wildcard listeners
> - Make sure that wild card listeners of same priority are always triggered AFTER the named event (so if one listener is attached to event "my.event" with priority 1 and one listener is attached to event "*" with priority 1, listener attached to "my.event" must be exeucted before, even if it was attached after the wildcard.
